### PR TITLE
添加缺失的依赖并优化了github action的工作流

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,9 +2,9 @@ name: Build Executable
 
 on:
   push:
-    branches: [ "*" ]
+    branches: ["*"]
   pull_request:
-    branches: [ "*" ]
+    branches: ["*"]
 
 jobs:
   build:
@@ -26,42 +26,42 @@ jobs:
           - os: ubuntu-latest
             platform: linux
             arch: x64
-            ext: 
+            ext:
 
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
-        architecture: ${{ matrix.arch }}
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          architecture: ${{ matrix.arch }}
 
-    - name: Cache pip
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cache/pip
-          ~/Library/Caches/pip  # macOS
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+            ~/Library/Caches/pip  # macOS
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install --cache-dir ~/.cache/pip -r requirements.txt
-        pip install --cache-dir ~/.cache/pip pyinstaller imageio
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install --cache-dir ~/.cache/pip -r requirements.txt
+          pip install --cache-dir ~/.cache/pip pyinstaller imageio
 
-    - name: Build Application
-      run: |
-        pyinstaller --noconfirm --name=LitematicaViewer --add-data "block:block" --add-data "item:item" --add-data "lang:lang" --add-data "icon.ico:." --add-data "tm_icon.ico:." --windowed --icon="icon.ico" --clean -D script/LitematicaViewer.py
+      - name: Build Application
+        run: |
+          pyinstaller --noconfirm --name=LitematicaViewer --add-data "block:block" --add-data "item:item" --add-data "lang:lang" --add-data "icon.ico:." --add-data "tm_icon.ico:." --windowed --icon="icon.ico" --clean -D script/LitematicaViewer.py
 
-    - name: Upload Artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: LitematicaViewer-${{ matrix.platform }}-${{ matrix.arch }}
-        path: |
-          dist/*
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: LitematicaViewer-${{ matrix.platform }}-${{ matrix.arch }}
+          path: |
+            dist/*

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,12 +39,21 @@ jobs:
         python-version: '3.11'
         architecture: ${{ matrix.arch }}
 
+    - name: Cache pip
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/pip
+          ~/Library/Caches/pip  # macOS
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install pyinstaller
-        pip install imageio
+        pip install --cache-dir ~/.cache/pip -r requirements.txt
+        pip install --cache-dir ~/.cache/pip pyinstaller imageio
 
     - name: Build Application
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ amulet-nbt==2.1.3
 pyopengl==3.1.9
 pyopengltk==0.0.4
 customtkinter>=5.2.2
+easygui==0.98.3


### PR DESCRIPTION
### 主要变更内容

#### 1. 依赖项修复
- **问题**：项目运行时缺少 `easygui` 模块
- **改动**：在 `requirements.txt` 中添加 `easygui==0.98.3`
- **影响**：确保用户通过 `pip install -r requirements.txt`或者运行`install.bat`能完整安装所有依赖

#### 2. GitHub Actions 优化
- **缓存策略**：添加 `~/.cache/pip` 目录缓存
  ```yaml
  pip install --cache-dir ~/.cache/pip
  ```
- **影响**：减少 CI 流水线重复下载依赖的时间

#### 3. 代码风格规范化
- **YAML 格式化**：使用 Prettier 统一 GitHub Actions 文件的格式